### PR TITLE
Add global TipTap editor styles

### DIFF
--- a/src/assets/tiptap.css
+++ b/src/assets/tiptap.css
@@ -1,0 +1,62 @@
+.tiptap {
+  line-height: 1.7;
+}
+
+.tiptap > * + * {
+  margin-top: 0.75em;
+}
+
+.tiptap h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.tiptap h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.tiptap h3 {
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.tiptap ul,
+.tiptap ol {
+  padding-left: 1.5rem;
+  margin: 0.5rem 0;
+}
+
+.tiptap ul {
+  list-style: disc;
+}
+
+.tiptap ol {
+  list-style: decimal;
+}
+
+.tiptap li {
+  margin: 0.25rem 0;
+}
+
+.tiptap blockquote {
+  border-left: 3px solid #e2e8f0;
+  padding-left: 0.75rem;
+  color: #475569;
+  font-style: italic;
+}
+
+.tiptap pre {
+  background: #0f172a;
+  color: #f8fafc;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  overflow-x: auto;
+}
+
+.tiptap code {
+  background: #f1f5f9;
+  border-radius: 0.25rem;
+  padding: 0.1rem 0.25rem;
+  font-size: 0.875em;
+}

--- a/src/components/TipTapEditor.vue
+++ b/src/components/TipTapEditor.vue
@@ -9,7 +9,7 @@ import { useTipTap } from '@/composables/useTipTap'
 import TipTapToolbar from '@/components/TipTapToolbar.vue'
 
 const DEFAULT_EDITOR_CLASS =
-  'min-h-[12rem] focus:outline-none prose prose-slate max-w-none text-slate-800'
+  'tiptap min-h-[12rem] focus:outline-none prose prose-slate max-w-none text-slate-800'
 
 const EXTENSION_MAP: Record<string, Extension> = {
   StarterKit,

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import ProsePre from '@nuxt/ui/components/prose/Pre.vue'
 import CoffeeCounter from './components/CoffeeCounter.vue'
 import CoffeeCounterCallout from './components/CoffeeCounterCallout.vue'
 import './assets/imports.css'
+import './assets/tiptap.css'
 import './assets/main.scss'
 import 'highlight.js/styles/github.css'
 


### PR DESCRIPTION
### Motivation
- HTML content injected into the TipTap editor was rendering without typical typographic styles because Tailwind’s base/reset removed list markers, margins, and heading sizing, so the editor needed an explicit stylesheet and a root class to restore visual defaults.

### Description
- Add a new global stylesheet at `src/assets/tiptap.css` with rules for headings, lists, blockquote, `pre` and `code` to restore readable typographic styles for editor content.
- Tag the editor root by prepending the `tiptap` class to the default editor class in `src/components/TipTapEditor.vue` so the new styles scope to the editor content.
- Import the stylesheet in the application entry `src/main.ts` so the TipTap styles load globally.

### Testing
- Launched the dev client with `npm run dev:client` and confirmed Vite reported the site as ready (Local and Network URLs), so assets are being served successfully.
- Ran an automated Playwright script to load `/tiptap-llm` and capture a screenshot, but Chromium crashed in the container and the screenshot step failed due to a browser SIGSEGV; no screenshot produced.
- No unit tests or vitest runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984a7ffef0c832d98b9c31023464261)